### PR TITLE
Making things work on Windows

### DIFF
--- a/src/com/redhat/ceylon/compiler/tools/LanguageCompiler.java
+++ b/src/com/redhat/ceylon/compiler/tools/LanguageCompiler.java
@@ -189,7 +189,7 @@ public class LanguageCompiler extends JavaCompiler {
 
                 ModuleBuilder moduleBuilder = phasedUnits.getModuleBuilder();
                 com.redhat.ceylon.compiler.typechecker.model.Package p = moduleBuilder.getCurrentPackage();
-                File sourceFile = new File(filename.toUri().getPath());
+                File sourceFile = new File(filename.toString());
                 // FIXME: temporary solution
                 VirtualFile file = vfs.getFromFile(sourceFile);
                 VirtualFile srcDir = vfs.getFromFile(getSrcDir(sourceFile));

--- a/test-src/com/redhat/ceylon/compiler/test/CompilerTest.java
+++ b/test-src/com/redhat/ceylon/compiler/test/CompilerTest.java
@@ -7,6 +7,7 @@ import java.io.Reader;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.regex.Matcher;
 
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
@@ -37,7 +38,7 @@ public abstract class CompilerTest {
 	@Before
 	public void setup(){
 		// for comparing with java source
-		String pkg = getClass().getPackage().getName().replaceAll("\\.", File.separator);
+		String pkg = getClass().getPackage().getName().replaceAll("\\.", Matcher.quoteReplacement(File.separator));
 		path = dir + File.separator + pkg + File.separator;
 		// for running
 		runCompiler = new CeyloncTool();
@@ -69,7 +70,8 @@ public abstract class CompilerTest {
 		enter.completeCeylonTrees(List.of(compilationUnit));
 		// now look at what we expected
 		String src = readFile(new File(path+java));
-		Assert.assertEquals(src.trim(), compilationUnit.toString().trim());
+		String src2 = normalizeLineEndings(compilationUnit.toString());
+		Assert.assertEquals(src.trim(), src2.trim());
 	}
 
 	private String readFile(File file) {
@@ -90,6 +92,12 @@ public abstract class CompilerTest {
 		}
 	}
 
+	private String normalizeLineEndings(String txt) {
+		String result = txt.replaceAll("\r\n", "\n"); // Windows
+		result = result.replaceAll("\r", "\n"); // Mac (OS<=9)
+		return result;
+	}
+	
 	protected void compileAndRun(String ceylon, String main) {
 		Iterable<? extends JavaFileObject> compilationUnits1 =
 			runFileManager.getJavaFileObjectsFromFiles(Arrays.asList(new File(path+ceylon)));


### PR DESCRIPTION
Hi,
I made a couple of simple changes to make the tests run correctly on Windows:
- first the generated compiler source uses platform specific line endings while the file to compare them to are UNIX format
- second the conversion from package name to folder path used File.separator which on Windows is \ which is a special char when used in String.replace() functions and has to be escaped
- and finally, and maybe a change that will break something, a conversion from file name to File object in the compiler which breaks on Windows. I tested the change on my Linux system as well and things still seem to work.
