### PR TITLE
Refactor, intoducing AbstractVisitor

### DIFF
--- a/src/com/redhat/ceylon/compiler/codegen/AbstractVisitor.java
+++ b/src/com/redhat/ceylon/compiler/codegen/AbstractVisitor.java
@@ -1,0 +1,168 @@
+package com.redhat.ceylon.compiler.codegen;
+
+import java.util.Collection;
+
+import com.redhat.ceylon.compiler.typechecker.tree.Node;
+import com.redhat.ceylon.compiler.typechecker.tree.Visitor;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.tree.JCTree.Factory;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+
+/**
+ * Abstract base class for Visitors providing access to the various 
+ * Transformers, convenience methods for appending to a list of JCTrees
+ * and obtaining the result after the visit.
+ * 
+ * @author Tom Bentley
+ *
+ * @param <J> The type of JCTree in the result list.
+ */
+public class AbstractVisitor<J extends JCTree> extends Visitor {
+
+    protected final CeylonTransformer gen;
+
+    protected final StatementTransformer statementGen;
+
+    protected final ExpressionTransformer expressionGen;
+
+    protected final ClassTransformer classGen;
+    
+    private final ListBuffer<J> defs;
+    
+    public AbstractVisitor(CeylonTransformer gen) {
+        this.gen = gen;
+        this.statementGen = gen.statementGen;
+        this.expressionGen = gen.expressionGen;
+        this.classGen = gen.classGen;
+        this.defs = new ListBuffer<J>();
+    }
+    
+    public AbstractVisitor(CeylonTransformer gen, ListBuffer<J> defs) {
+        this.gen = gen;
+        this.statementGen = gen.statementGen;
+        this.expressionGen = gen.expressionGen;
+        this.classGen = gen.classGen;
+        this.defs = defs;
+    }
+    
+    /**
+     * Gets all the results which were appended during the visit
+     * @return The results
+     * 
+     * @see #getSingleResult()
+     */
+    public ListBuffer<J> getResult() {
+        return defs;
+    }
+    
+    /**
+     * Asserts that there's a single result, and returns it
+     * @return The result
+     * 
+     * @see #getResult()
+     */
+    public J getSingleResult() {
+        if (defs.size() != 1) {
+            throw new RuntimeException();
+        }
+        return defs.first();
+    }
+    
+    public boolean addAll(Collection<? extends J> c) {
+        return defs.addAll(c);
+    }
+
+    protected boolean add(J result) {
+        return defs.add(result);
+    }
+    
+    public ListBuffer<J> append(J x) {
+        return defs.append(x);
+    }
+
+    public ListBuffer<J> appendList(List<J> xs) {
+        return defs.appendList(xs);
+    }
+    
+    public ListBuffer<J> appendList(ListBuffer<J> xs) {
+        return defs.appendList(xs);
+    }
+
+    public ListBuffer<J> appendArray(J[] xs) {
+        return defs.appendArray(xs);
+    }
+    
+    protected Factory at(Node node) {
+        return gen.at(node);
+    }
+
+    protected JCExpression makeIdent(String ident) {
+        return gen.makeIdent(ident);
+    }
+
+    protected JCExpression makeIdent(Iterable<String> ident) {
+        return gen.makeIdent(ident);
+    }
+
+    protected JCExpression makeIdent(String... ident) {
+        return gen.makeIdent(ident);
+    }
+
+    protected JCExpression makeIdent(Type type) {
+        return gen.makeIdent(type);
+    }
+
+    protected JCExpression makeBoolean(boolean b) {
+        JCExpression expr;
+        if (b) {
+            expr = makeIdent("ceylon", "language", "$true", "getTrue");
+        } else {
+            expr = makeIdent("ceylon", "language", "$false", "getFalse");
+        }
+        return make().Apply(List.<JCTree.JCExpression>nil(), expr, List.<JCTree.JCExpression>nil());
+    }
+
+    protected JCExpression makeBooleanTest(JCExpression expr, boolean val) {
+        return make().Binary(JCTree.EQ, expr, makeBoolean(val));
+    }
+    
+    protected TreeMaker make() {
+        return gen.make();
+    }
+
+    protected Symtab syms() {
+        return gen.syms;
+    }
+
+    protected JCFieldAccess makeSelect(JCExpression s1, String s2) {
+        return gen.makeSelect(s1, s2);
+    }
+
+    protected JCFieldAccess makeSelect(String s1, String s2) {
+        return makeSelect(make().Ident(names().fromString(s1)), s2);
+    }
+
+    protected Name.Table names() {
+        return gen.names;
+    }
+
+    protected String tempName() {
+        return gen.tempName();
+    }
+
+    protected String tempName(String prefix) {
+        return gen.tempName(prefix);
+    }
+
+    protected String aliasName(String name) {
+        return gen.aliasName(name);
+    }
+    
+}

--- a/src/com/redhat/ceylon/compiler/codegen/StatementTransformer.java
+++ b/src/com/redhat/ceylon/compiler/codegen/StatementTransformer.java
@@ -40,12 +40,12 @@ public class StatementTransformer extends AbstractTransformer {
     }
 
     List<JCStatement> transformStmts(java.util.List<Tree.Statement> list) {
-        StatementVisitor v = new StatementVisitor(this);
+        StatementVisitor v = new StatementVisitor(this.gen);
 
         for (Tree.Statement stmt : list)
             stmt.visit(v);
 
-        return v.stmts().toList();
+        return v.getResult().toList();
     }
 
     List<JCStatement> transform(Tree.IfStatement stmt) {

--- a/src/com/redhat/ceylon/compiler/codegen/StatementVisitor.java
+++ b/src/com/redhat/ceylon/compiler/codegen/StatementVisitor.java
@@ -1,31 +1,22 @@
 package com.redhat.ceylon.compiler.codegen;
 
-import com.redhat.ceylon.compiler.typechecker.tree.NaturalVisitor;
-import com.redhat.ceylon.compiler.typechecker.tree.Tree;
-import com.redhat.ceylon.compiler.typechecker.tree.Visitor;
-import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
-import com.sun.tools.javac.util.List;
-import com.sun.tools.javac.util.ListBuffer;
-
 import static com.sun.tools.javac.code.Flags.FINAL;
 
-class StatementVisitor extends Visitor implements NaturalVisitor {
-    final ListBuffer<JCTree.JCStatement> stmts = ListBuffer.lb();
-    private StatementTransformer statementGen;
-    private ExpressionTransformer expressionGen;
+import com.redhat.ceylon.compiler.typechecker.tree.NaturalVisitor;
+import com.redhat.ceylon.compiler.typechecker.tree.Tree;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.List;
 
-    StatementVisitor(StatementTransformer statementGen) {
-        this.statementGen = statementGen;
-        this.expressionGen = statementGen.gen.expressionGen;
-    }
+class StatementVisitor extends AbstractVisitor<JCStatement> implements NaturalVisitor {
 
-    public ListBuffer<JCTree.JCStatement> stmts() {
-        return stmts;
+    StatementVisitor(CeylonTransformer gen) {
+        super(gen);
     }
 
     public void visit(Tree.InvocationExpression expr) {
-        append(statementGen.at(expr).Exec(expressionGen.transform(expr)));
+        append(at(expr).Exec(expressionGen.transform(expr)));
     }
 
     public void visit(Tree.Return ret) {
@@ -33,11 +24,11 @@ class StatementVisitor extends Visitor implements NaturalVisitor {
     }
 
     public void visit(Tree.IfStatement stat) {
-        append(statementGen.transform(stat));
+        appendList(statementGen.transform(stat));
     }
 
     public void visit(Tree.WhileStatement stat) {
-        append(statementGen.transform(stat));
+        appendList(statementGen.transform(stat));
     }
 
 //    public void visit(Tree.DoWhileStatement stat) {
@@ -45,11 +36,11 @@ class StatementVisitor extends Visitor implements NaturalVisitor {
 //    }
 
     public void visit(Tree.ForStatement stat) {
-        append(statementGen.transform(stat));
+        appendList(statementGen.transform(stat));
     }
 
     public void visit(Tree.Break stat) {
-        append(statementGen.transform(stat));
+        appendList(statementGen.transform(stat));
     }
 
     public void visit(Tree.AttributeDeclaration decl) {
@@ -62,22 +53,22 @@ class StatementVisitor extends Visitor implements NaturalVisitor {
 
     // FIXME: not sure why we don't have just an entry for Tree.Term here...
     public void visit(Tree.OperatorExpression op) {
-        append(statementGen.at(op).Exec(expressionGen.transformExpression(op)));
+        append(at(op).Exec(expressionGen.transformExpression(op)));
     }
 
     public void visit(Tree.Expression tree) {
-        append(statementGen.at(tree).Exec(expressionGen.transformExpression(tree)));
+        append(at(tree).Exec(expressionGen.transformExpression(tree)));
     }
 
     public void visit(Tree.MethodDefinition decl) {
-        JCTree.JCClassDecl innerDecl = statementGen.gen.classGen.methodClass(decl);
+        JCTree.JCClassDecl innerDecl = classGen.methodClass(decl);
         append(innerDecl);
-        JCTree.JCIdent name = statementGen.make().Ident(innerDecl.name);
-        JCVariableDecl call = statementGen.at(decl).VarDef(
-                statementGen.make().Modifiers(FINAL),
-                statementGen.names().fromString(decl.getIdentifier().getText()),
+        JCTree.JCIdent name = make().Ident(innerDecl.name);
+        JCVariableDecl call = at(decl).VarDef(
+                make().Modifiers(FINAL),
+                names().fromString(decl.getIdentifier().getText()),
                 name,
-                statementGen.at(decl).NewClass(null, null, name, List.<JCTree.JCExpression>nil(), null));
+                at(decl).NewClass(null, null, name, List.<JCTree.JCExpression>nil(), null));
         append(call);
     }
 
@@ -89,22 +80,14 @@ class StatementVisitor extends Visitor implements NaturalVisitor {
 
     // FIXME: I think those should just go in transformExpression no?
     public void visit(Tree.PostfixOperatorExpression expr) {
-        append(statementGen.at(expr).Exec(expressionGen.transform(expr)));
+        append(at(expr).Exec(expressionGen.transform(expr)));
     }
 
     public void visit(Tree.PrefixOperatorExpression expr) {
-        append(statementGen.at(expr).Exec(expressionGen.transform(expr)));
+        append(at(expr).Exec(expressionGen.transform(expr)));
     }
 
     public void visit(Tree.ExpressionStatement tree) {
-        append(statementGen.at(tree).Exec(expressionGen.transformExpression(tree.getExpression())));
-    }
-
-    private void append(JCTree.JCStatement stmt) {
-        stmts.append(stmt);
-    }
-
-    private void append(List<JCTree.JCStatement> list) {
-        stmts.appendList(list);
+        append(at(tree).Exec(expressionGen.transformExpression(tree.getExpression())));
     }
 }


### PR DESCRIPTION
Introduce AbstractVisitor allowing visitors to conveniently append to a list of JCTrees and return the result after the visit.

Refactor all existing Visitors to use AbstractVisitor. Remove Singleton because it's no longer needed -- AbstractVisitor.getSingleResult() achieves the same thing.

Use static inner classes for those visitors which were anon local classes before. Whether this really improves anything is debatable, but I felt it was an improvement, and at least those classes have names now.
