### PR TITLE
Implementation of 'throw' and 'try' statements.

### DIFF
--- a/langtools/src/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/langtools/src/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -176,6 +176,7 @@ public class Symtab {
     public  Type ceylonEntryType;
     public  Type ceylonContainerType;
     public  Type ceylonNamedArgumentCall;
+    public  Type ceylonExceptionType;
 
     public final Type ceylonAtCeylonType;
     public final Type ceylonAtNameType;
@@ -715,5 +716,6 @@ public class Symtab {
         ceylonEntryType = enterClass("ceylon.language.Entry");
         ceylonContainerType = enterClass("ceylon.language.Container");
         ceylonNamedArgumentCall = enterClass("ceylon.language.NamedArgumentCall");
+        ceylonExceptionType = enterClass("ceylon.language.Exception");
     }
 }

--- a/runtime/ceylon/language/Exception.java
+++ b/runtime/ceylon/language/Exception.java
@@ -1,0 +1,22 @@
+package ceylon.language;
+
+import com.redhat.ceylon.compiler.metadata.java.TypeInfo;
+
+public class Exception extends IdentifiableObject {
+
+    public Exception(
+            @TypeInfo("ceylon.language.String|ceylon.language.Nothing")
+            ceylon.language.String message,
+            @TypeInfo("ceylon.language.Exception|ceylon.language.Nothing")
+            java.lang.Throwable t) {
+        // This isn't actually used at runtime, but is required by the type checker
+    }
+    
+    /*public Exception getCause() {
+        return cause;
+    }*/
+    
+    public ceylon.language.String getMessage() {
+        return null;
+    }
+}

--- a/src/com/redhat/ceylon/compiler/codegen/AbstractTransformer.java
+++ b/src/com/redhat/ceylon/compiler/codegen/AbstractTransformer.java
@@ -333,6 +333,13 @@ public abstract class AbstractTransformer implements Transformation {
                 || typeFact().isUnion(type));
     }
     
+    protected boolean willEraseToRuntimeException(ProducedType type) {
+        type = simplifyType(type);
+        return (sameType(syms().ceylonExceptionType, type)
+                || sameType(syms().throwableType, type)
+                || sameType(syms().exceptionType, type));
+    }
+
     protected boolean isCeylonString(ProducedType type) {
         return (sameType(syms().ceylonStringType, type));
     }
@@ -397,6 +404,8 @@ public abstract class AbstractTransformer implements Transformation {
                     return make().Type(syms().objectType);
                 }
             }
+        } else if (willEraseToRuntimeException(type)) {
+            return make().Type(syms().runtimeExceptionType);
         } else if (satisfiesOrExtendsOrTypeParam == 0 && !isOptional(type)) {
             if (isCeylonString(type)) {
                 return make().Type(syms().stringType);

--- a/src/com/redhat/ceylon/compiler/codegen/CeylonVisitor.java
+++ b/src/com/redhat/ceylon/compiler/codegen/CeylonVisitor.java
@@ -247,6 +247,14 @@ public class CeylonVisitor extends Visitor implements NaturalVisitor {
         classBuilder.extending(extendedType);
     }
 
+    public void visit(Tree.Throw t) {
+        append(gen.statementGen().transform(t));
+    }
+
+    public void visit(Tree.TryCatchStatement t) {
+        append(gen.statementGen().transform(t));
+    }
+
     // FIXME: implement
     public void visit(Tree.TypeConstraint l) {
     }

--- a/src/com/redhat/ceylon/compiler/codegen/ClassDefinitionBuilder.java
+++ b/src/com/redhat/ceylon/compiler/codegen/ClassDefinitionBuilder.java
@@ -247,8 +247,17 @@ public class ClassDefinitionBuilder {
         if (extendedType.getInvocationExpression().getPositionalArgumentList() != null) {
             List<JCExpression> args = List.<JCExpression> nil();
 
-            for (Tree.PositionalArgument arg : extendedType.getInvocationExpression().getPositionalArgumentList().getPositionalArguments())
-                args = args.append(gen.expressionGen().transformArg(arg));
+            int index = 0;
+            for (Tree.PositionalArgument arg : extendedType.getInvocationExpression().getPositionalArgumentList().getPositionalArguments()) {
+                if (index == 0 
+                        && extendedType.getInvocationExpression().getTypeModel().isExactly(gen.typeFact().getExceptionType())) {
+                    // unbox message argument to super for direct subclasses of Exception
+                    args = args.append(gen.unboxType(gen.expressionGen().transformArg(arg), gen.typeFact().getStringType()));
+                } else {
+                    args = args.append(gen.expressionGen().transformArg(arg));
+                }
+                index += 1;
+            }
 
             init(gen.at(extendedType).Exec(gen.make().Apply(List.<JCExpression> nil(), gen.make().Ident(gen.names()._super), args)));
         }

--- a/src/com/redhat/ceylon/compiler/loader/TypeFactory.java
+++ b/src/com/redhat/ceylon/compiler/loader/TypeFactory.java
@@ -132,6 +132,22 @@ public class TypeFactory {
     public Class getEntryDeclaration() {
         return (Class) ((TypeDeclaration) getLanguageModuleDeclaration("Entry"));
     }
+
+    /**
+     * Gets the declaration of {@code Exception}
+     * @return The declaration
+     */
+    public Class getExceptionDeclaration() {
+        return (Class) ((TypeDeclaration) getLanguageModuleDeclaration("Exception"));
+    }
+
+    /**
+     * Gets the declaration of {@code String}
+     * @return The declaration
+     */
+    public Class getStringDeclaration() {
+        return (Class) ((TypeDeclaration) getLanguageModuleDeclaration("String"));
+    }
     
     /**
      * Gets the declaration of {@code Range}
@@ -339,5 +355,13 @@ public class TypeFactory {
 
     public ProducedType getNonemptyIterableType(ProducedType pt) {
         return pt.minus(getEmptyDeclaration()).getSupertype(getIterableDeclaration());
+    }
+
+    public ProducedType getExceptionType() {
+        return getExceptionDeclaration().getType();
+    }
+
+    public ProducedType getStringType() {
+        return getStringDeclaration().getType();
     }
 }

--- a/test-src/com/redhat/ceylon/compiler/test/expression/attribute/IndirectQualifiedAttributeAccess.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/attribute/IndirectQualifiedAttributeAccess.src
@@ -18,6 +18,6 @@ class IndirectQualifiedAttributeAccess {
     
     IndirectQualifiedAttributeAccess() {
         this.b = true;
-        this.q = new IndirectQualifiedAttributeAccess();
+        this.q = new com.redhat.ceylon.compiler.test.expression.attribute.IndirectQualifiedAttributeAccess();
     }
 }

--- a/test-src/com/redhat/ceylon/compiler/test/expression/attribute/QualifiedAttributeAccess.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/attribute/QualifiedAttributeAccess.src
@@ -30,11 +30,11 @@ class QualifiedAttributeAccess {
     }
     
     private final boolean m3() {
-        return new QualifiedAttributeAccess().getB();
+        return new com.redhat.ceylon.compiler.test.expression.attribute.QualifiedAttributeAccess().getB();
     }
     
     private final boolean m4() {
-        return new QualifiedAttributeAccess().getB2();
+        return new com.redhat.ceylon.compiler.test.expression.attribute.QualifiedAttributeAccess().getB2();
     }
     
     private final boolean m5() {
@@ -52,7 +52,7 @@ class QualifiedAttributeAccess {
     QualifiedAttributeAccess() {
         this.b = true;
         this.b2 = true;
-        this.q = new QualifiedAttributeAccess();
+        this.q = new com.redhat.ceylon.compiler.test.expression.attribute.QualifiedAttributeAccess();
     }
 }
 class Foo {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/attribute/QualifiedAttributeAssign.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/attribute/QualifiedAttributeAssign.src
@@ -28,8 +28,8 @@ class QualifiedAttributeAssign {
     private final void m(final com.redhat.ceylon.compiler.test.expression.attribute.Foo f) {
         this.setB(false);
         this.setB2(false);
-        new QualifiedAttributeAssign().setB(true);
-        new QualifiedAttributeAssign().setB2(true);
+        new com.redhat.ceylon.compiler.test.expression.attribute.QualifiedAttributeAssign().setB(true);
+        new com.redhat.ceylon.compiler.test.expression.attribute.QualifiedAttributeAssign().setB2(true);
         getQ().setB(getQ().getB2());
         f.setB(f.getB());
     }
@@ -37,7 +37,7 @@ class QualifiedAttributeAssign {
     QualifiedAttributeAssign() {
         this.b = true;
         this.b2 = true;
-        this.q = new QualifiedAttributeAssign();
+        this.q = new com.redhat.ceylon.compiler.test.expression.attribute.QualifiedAttributeAssign();
     }
 }
 class Foo {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/attribute/TopLevelAssign.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/attribute/TopLevelAssign.src
@@ -51,6 +51,7 @@ final class b3 {
     
     static void setB3(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("ceylon.language.Boolean")
     boolean b3) {
+        throw new java.lang.RuntimeException();
     }
     
     private b3() {
@@ -67,6 +68,7 @@ public final class b4 {
     
     public static void setB4(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("ceylon.language.Boolean")
     boolean b4) {
+        throw new java.lang.RuntimeException();
     }
     
     private b4() {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/instantiation/ClassInstantiation.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/instantiation/ClassInstantiation.src
@@ -3,7 +3,7 @@ package com.redhat.ceylon.compiler.test.expression.instantiation;
 class ClassInstantiation {
     
     public final com.redhat.ceylon.compiler.test.expression.instantiation.ClassInstantiation m() {
-        return new ClassInstantiation();
+        return new com.redhat.ceylon.compiler.test.expression.instantiation.ClassInstantiation();
     }
     
     ClassInstantiation() {
@@ -12,7 +12,7 @@ class ClassInstantiation {
 class ClassInstantiationWithParam {
     
     public final com.redhat.ceylon.compiler.test.expression.instantiation.ClassInstantiationWithParam m() {
-        return new ClassInstantiationWithParam(2L);
+        return new com.redhat.ceylon.compiler.test.expression.instantiation.ClassInstantiationWithParam(2L);
     }
     
     ClassInstantiationWithParam(long i) {
@@ -21,7 +21,7 @@ class ClassInstantiationWithParam {
 class ClassInstantiationWithParams {
     
     public final com.redhat.ceylon.compiler.test.expression.instantiation.ClassInstantiationWithParams m() {
-        return new ClassInstantiationWithParams(2L, "");
+        return new com.redhat.ceylon.compiler.test.expression.instantiation.ClassInstantiationWithParams(2L, "");
     }
     
     ClassInstantiationWithParams(long i, .java.lang.String j) {
@@ -36,7 +36,7 @@ class InnerClassInstantiation {
     }
     
     private final void m() {
-        final com.redhat.ceylon.compiler.test.expression.instantiation.InnerClassInstantiation.InnerClass x = new InnerClass();
+        final com.redhat.ceylon.compiler.test.expression.instantiation.InnerClassInstantiation.InnerClass x = new com.redhat.ceylon.compiler.test.expression.instantiation.InnerClassInstantiation.InnerClass();
     }
     
     InnerClassInstantiation() {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/instantiation/GenericClassInstantiation.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/instantiation/GenericClassInstantiation.src
@@ -12,16 +12,16 @@ public class KlassTypeParams<U, V> {
 class KlassTypeParamsInstantiation {
     
     public final com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural> m() {
-        return new <ceylon.language.String, ceylon.language.Natural>KlassTypeParams(.ceylon.language.String.instance("foo"), .ceylon.language.Natural.instance(2L));
+        return new <ceylon.language.String, ceylon.language.Natural>com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural>(.ceylon.language.String.instance("foo"), .ceylon.language.Natural.instance(2L));
     }
     
     public final .java.lang.String m2() {
-        final com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural> k = new <ceylon.language.String, ceylon.language.Natural>KlassTypeParams(.ceylon.language.String.instance("foo"), .ceylon.language.Natural.instance(2L));
+        final com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural> k = new <ceylon.language.String, ceylon.language.Natural>com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural>(.ceylon.language.String.instance("foo"), .ceylon.language.Natural.instance(2L));
         return k.foo(.ceylon.language.String.instance("hello"), .ceylon.language.Natural.instance(1L)).toString();
     }
     
     public final .java.lang.String m3() {
-        final com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural> k = new <ceylon.language.String, ceylon.language.Natural>KlassTypeParams(.ceylon.language.String.instance("foo"), .ceylon.language.Natural.instance(2L));
+        final com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural> k = new <ceylon.language.String, ceylon.language.Natural>com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural>(.ceylon.language.String.instance("foo"), .ceylon.language.Natural.instance(2L));
         return new .ceylon.language.NamedArgumentCall<com.redhat.ceylon.compiler.test.expression.instantiation.KlassTypeParams<ceylon.language.String, ceylon.language.Natural>>(k, .ceylon.language.String.instance("hello"), .ceylon.language.Natural.instance(1L)){
             
             public ceylon.language.String call$() {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/invoke/ChainedInvocations.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/invoke/ChainedInvocations.src
@@ -3,7 +3,7 @@ package com.redhat.ceylon.compiler.test.expression.invoke;
 class ChainedInvocations {
     
     private final long m() {
-        return new ChainedInvocations().foo();
+        return new com.redhat.ceylon.compiler.test.expression.invoke.ChainedInvocations().foo();
     }
     
     private final long foo() {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/invoke/GenericMethodInvocation.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/invoke/GenericMethodInvocation.src
@@ -12,12 +12,12 @@ public class KlassMethodTypeParams {
 class GenericMethodInvocation {
     
     public final .java.lang.String m() {
-        final com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams k = new KlassMethodTypeParams();
+        final com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams k = new com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams();
         return k.<ceylon.language.String, ceylon.language.Natural>bar(.ceylon.language.String.instance("hello"), .ceylon.language.Natural.instance(1L)).toString();
     }
     
     public final .java.lang.String m2() {
-        final com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams k = new KlassMethodTypeParams();
+        final com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams k = new com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams();
         return new .ceylon.language.NamedArgumentCall<com.redhat.ceylon.compiler.test.expression.invoke.KlassMethodTypeParams>(k, .ceylon.language.String.instance("hello"), .ceylon.language.Natural.instance(1L)){
             
             public ceylon.language.String call$() {

--- a/test-src/com/redhat/ceylon/compiler/test/expression/invoke/NamedArgumentInvocation.src
+++ b/test-src/com/redhat/ceylon/compiler/test/expression/invoke/NamedArgumentInvocation.src
@@ -42,14 +42,14 @@ class NamedArgumentInvocation {
     }
     
     private final boolean qualified() {
-        new .ceylon.language.NamedArgumentCall<com.redhat.ceylon.compiler.test.expression.invoke.NamedArgumentInvocation>(new NamedArgumentInvocation(), .ceylon.language.String.instance("bar"), .ceylon.language.Natural.instance(2L)){
+        new .ceylon.language.NamedArgumentCall<com.redhat.ceylon.compiler.test.expression.invoke.NamedArgumentInvocation>(new com.redhat.ceylon.compiler.test.expression.invoke.NamedArgumentInvocation(), .ceylon.language.String.instance("bar"), .ceylon.language.Natural.instance(2L)){
             
             public .java.lang.Object call$() {
                 this.instance.v(((ceylon.language.Natural)this.args[1]).longValue(), ((ceylon.language.String)this.args[0]).toString());
                 return null;
             }
         }.call$();
-        return new .ceylon.language.NamedArgumentCall<com.redhat.ceylon.compiler.test.expression.invoke.NamedArgumentInvocation>(new NamedArgumentInvocation(), .ceylon.language.String.instance("bar"), .ceylon.language.Natural.instance(2L)){
+        return new .ceylon.language.NamedArgumentCall<com.redhat.ceylon.compiler.test.expression.invoke.NamedArgumentInvocation>(new com.redhat.ceylon.compiler.test.expression.invoke.NamedArgumentInvocation(), .ceylon.language.String.instance("bar"), .ceylon.language.Natural.instance(2L)){
             
             public boolean call$() {
                 return this.instance.f(((ceylon.language.Natural)this.args[1]).longValue(), ((ceylon.language.String)this.args[0]).toString());

--- a/test-src/com/redhat/ceylon/compiler/test/model/annotations/UnionTypeInfo.src
+++ b/test-src/com/redhat/ceylon/compiler/test/model/annotations/UnionTypeInfo.src
@@ -23,7 +23,7 @@ class UnionTypeInfo {
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     private final .java.lang.Object getGetter() {
-        return new Foo();
+        return new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
     
     private final void setGetter(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("ceylon.language.Void")
@@ -32,7 +32,7 @@ class UnionTypeInfo {
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     public final .java.lang.Object getSharedGetter() {
-        return new Foo();
+        return new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
     
     public final void setSharedGetter(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("ceylon.language.Void")
@@ -42,14 +42,14 @@ class UnionTypeInfo {
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     private final .java.lang.Object method(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     final .java.lang.Object methodParam) {
-        final .java.lang.Object val = new Foo();
+        final .java.lang.Object val = new com.redhat.ceylon.compiler.test.model.annotations.Foo();
         return val;
     }
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     public final .java.lang.Object sharedMethod(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     final .java.lang.Object methodParam) {
-        final .java.lang.Object val = new Foo();
+        final .java.lang.Object val = new com.redhat.ceylon.compiler.test.model.annotations.Foo();
         return val;
     }
     
@@ -57,7 +57,7 @@ class UnionTypeInfo {
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     .java.lang.Object param) {
         final .java.lang.Object attr;
-        this.sharedAttr = new Foo();
+        this.sharedAttr = new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
 }
 @.com.redhat.ceylon.compiler.metadata.java.Ceylon
@@ -71,7 +71,7 @@ public class SharedUnionTypeInfo {
 @.com.redhat.ceylon.compiler.metadata.java.Ceylon
 @.com.redhat.ceylon.compiler.metadata.java.Attribute
 final class toplevelAttribute {
-    private static final .java.lang.Object value = new Foo();
+    private static final .java.lang.Object value = new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     static .java.lang.Object getToplevelAttribute() {
@@ -84,7 +84,7 @@ final class toplevelAttribute {
 @.com.redhat.ceylon.compiler.metadata.java.Ceylon
 @.com.redhat.ceylon.compiler.metadata.java.Attribute
 public final class sharedToplevelAttribute {
-    private static final .java.lang.Object value = new Bar();
+    private static final .java.lang.Object value = new com.redhat.ceylon.compiler.test.model.annotations.Bar();
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     public static .java.lang.Object getSharedToplevelAttribute() {
@@ -104,7 +104,7 @@ final class toplevelMethod {
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     static .java.lang.Object toplevelMethod(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     final .java.lang.Object param) {
-        return new Foo();
+        return new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
 }
 @.com.redhat.ceylon.compiler.metadata.java.Ceylon
@@ -117,7 +117,7 @@ public final class sharedToplevelMethod {
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     public static .java.lang.Object sharedToplevelMethod(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     final .java.lang.Object param) {
-        return new Foo();
+        return new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
 }
 @.com.redhat.ceylon.compiler.metadata.java.Ceylon
@@ -126,7 +126,7 @@ final class toplevelGetter {
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     static .java.lang.Object getToplevelGetter() {
-        return new Foo();
+        return new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
     
     static void setToplevelGetter(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
@@ -142,7 +142,7 @@ public final class toplevelSharedGetter {
     
     @.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")
     public static .java.lang.Object getToplevelSharedGetter() {
-        return new Foo();
+        return new com.redhat.ceylon.compiler.test.model.annotations.Foo();
     }
     
     public static void setToplevelSharedGetter(@.com.redhat.ceylon.compiler.metadata.java.TypeInfo("com.redhat.ceylon.compiler.test.model.annotations.Foo|com.redhat.ceylon.compiler.test.model.annotations.Bar")

--- a/test-src/com/redhat/ceylon/compiler/test/statement/StatementTest.java
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/StatementTest.java
@@ -208,11 +208,6 @@ public class StatementTest extends CompilerTest {
     }
     
     @Test
-    public void testTryThrowLocal(){
-        compareWithJavaSource("trycatch/ThrowLocal");
-    }
-    
-    @Test
     public void testTryTryFinally(){
         compareWithJavaSource("trycatch/TryFinally");
     }
@@ -230,11 +225,6 @@ public class StatementTest extends CompilerTest {
     @Test
     public void testTryTryCatchSubclass(){
         compareWithJavaSource("trycatch/TryCatchSubclass");
-    }
-    
-    @Test
-    public void testTryTryCatchIntersection(){
-        compareWithJavaSource("trycatch/TryCatchIntersection");
     }
     
     @Test

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/JavaThrower.java
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/JavaThrower.java
@@ -8,24 +8,24 @@ public class JavaThrower {
         
     }
     
-    public long throwException() throws Exception {
+    public boolean throwException() throws Exception {
         throw new Exception();
     }
     
-    public long throwThrowable() throws Throwable {
+    public boolean throwThrowable() throws Throwable {
         throw new Throwable();
     }
     
-    public long throwRuntimeException() throws RuntimeException {
+    public boolean throwRuntimeException() throws RuntimeException {
         throw new RuntimeException();
     }
     
-    public long throwError() throws Error {
+    public boolean throwError() throws Error {
         throw new Error();
     }
     
-    public long throwsMultiple() throws ClassNotFoundException, IOException {
-        return 0;
+    public boolean throwsMultiple() throws ClassNotFoundException, IOException {
+        return false;
     }
     
 }

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/ThrowException.src
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/ThrowException.src
@@ -3,7 +3,7 @@ package com.redhat.ceylon.compiler.test.statement.trycatch;
 class ThrowException {
     
     private final void t() {
-        throw new java.lang.RuntimeException("Bang!", null);
+        throw new .java.lang.RuntimeException(.ceylon.language.String.instance("Bang!").toString(), null);
     }
     
     ThrowException() {

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/ThrowExceptionSubclass.src
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/ThrowExceptionSubclass.src
@@ -1,3 +1,5 @@
+package com.redhat.ceylon.compiler.test.statement.trycatch;
+
 class E extends .java.lang.RuntimeException {
     
     E(ceylon.language.String message, .java.lang.RuntimeException cause) {

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/ThrowMethodResult.src
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/ThrowMethodResult.src
@@ -1,13 +1,15 @@
+package com.redhat.ceylon.compiler.test.statement.trycatch;
+
 class ThrowMethodResult {
     
-    private final java.lang.RuntimeException e() {
-        return new java.lang.RuntimeException("Bang!", null);
+    private final .java.lang.RuntimeException e() {
+        return new .java.lang.RuntimeException(.ceylon.language.String.instance("Bang!").toString(), null);
     }
     
     private final void t() {
         throw e();
     }
     
-    ThrowExceptionResult() {
+    ThrowMethodResult() {
     }
 }

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/TryCatchSubclass.src
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/TryCatchSubclass.src
@@ -9,24 +9,24 @@ class E extends .java.lang.RuntimeException {
 class TryCatchSubclass {
     
     private final void t() {
-        throw new .java.lang.RuntimeException("Bang!", null);
     }
     
-    private final void ce(final E e) {
+    private final void ce(final com.redhat.ceylon.compiler.test.statement.trycatch.E e) {
     }
+    
     private final void cexception(final .java.lang.RuntimeException e) {
     }
     
     private final void m() {
         try {
             t();
-        } catch (final E e) {
-            c(e);
+        } catch (final com.redhat.ceylon.compiler.test.statement.trycatch.E e) {
+            ce(e);
         } catch (final .java.lang.RuntimeException e) {
-            c(e);
+            cexception(e);
         }
     }
     
-    TryCatch() {
+    TryCatchSubclass() {
     }
 }

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/TryCatchUnion.src
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/TryCatchUnion.src
@@ -1,3 +1,5 @@
+package com.redhat.ceylon.compiler.test.statement.trycatch;
+
 class E1 extends .java.lang.RuntimeException {
     
     E1(ceylon.language.String message, .java.lang.RuntimeException cause) {
@@ -21,9 +23,9 @@ class TryCatchUnion {
     private final void m() {
         try {
             t();
-        } catch (final E1 e) {
+        } catch (final com.redhat.ceylon.compiler.test.statement.trycatch.E1 e) {
             c(e);
-        } catch (final E2 e) {
+        } catch (final com.redhat.ceylon.compiler.test.statement.trycatch.E2 e) {
             c(e);
         }
     }

--- a/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/WrapExceptionAtJavaCallSite.ceylon
+++ b/test-src/com/redhat/ceylon/compiler/test/statement/trycatch/WrapExceptionAtJavaCallSite.ceylon
@@ -2,11 +2,11 @@
 class ReplaceExceptionAtJavaCallSite() {
     void m() {
         JavaThrower jt = JavaThrower();
-        Natural n = jt.throwException();
-        Natural m = jt.throwThrowable();
-        Natural x = jt.throwRuntimeException();
-        Natural y = jt.throwError();
-        Natural z = jt.throwsMultiple();
+        Boolean n = jt.throwException();
+        Boolean m = jt.throwThrowable();
+        Boolean x = jt.throwRuntimeException();
+        Boolean y = jt.throwError();
+        Boolean z = jt.throwsMultiple();
     }
 
 }

--- a/test-src/com/redhat/ceylon/compiler/test/structure/type/Conversions.src
+++ b/test-src/com/redhat/ceylon/compiler/test/structure/type/Conversions.src
@@ -77,11 +77,11 @@ class ExtBottom extends com.redhat.ceylon.compiler.test.structure.type.GenInv {
 class Conversions {
     
     public final void m() {
-        final com.redhat.ceylon.compiler.test.structure.type.Foo c1 = new Foo();
+        final com.redhat.ceylon.compiler.test.structure.type.Foo c1 = new com.redhat.ceylon.compiler.test.structure.type.Foo();
         c1.a();
         final ceylon.language.Natural n1 = .ceylon.language.Natural.instance(1L);
         final ceylon.language.Natural n2 = null;
-        final .java.lang.Object u1 = new Bar();
+        final .java.lang.Object u1 = new com.redhat.ceylon.compiler.test.structure.type.Bar();
         ((com.redhat.ceylon.compiler.test.structure.type.Foo)u1).a();
         final .java.lang.Object $u1$0 = u1;
         if ($u1$0 instanceof com.redhat.ceylon.compiler.test.structure.type.Bar) {


### PR DESCRIPTION
Implementation of 'throw' and 'try' statements. c.l.Exception is erased to j.l.RuntimeException. A couple of ugly hacks to unbox the constructor argument. Instantiation now uses makeJavaType(), which results in qualified names hence changes to otherwise unrelated .src.
