### PR TITLE
Tests for Java keywords avoidance

### DIFF
--- a/test-src/com/redhat/ceylon/compiler/test/misc/MiscTest.java
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/MiscTest.java
@@ -63,4 +63,30 @@ public class MiscTest extends CompilerTest {
         Boolean result = task.call();
         Assert.assertEquals("Compilation failed", Boolean.TRUE, result);
     }
+    
+    //
+    // Java keyword avoidance
+    // Note class names and generic type arguments are not a problem because
+    // in Ceylon they must begin with an upper case latter, but the Java
+    // keywords are all lowercase 
+    
+    @Test
+    public void testKeywordVariable(){
+        compareWithJavaSource("keyword/Variable");
+    }
+    
+    @Test
+    public void testKeywordAttribute(){
+        compareWithJavaSource("keyword/Attribute");
+    }
+    
+    @Test
+    public void testKeywordMethod(){
+        compareWithJavaSource("keyword/Method");
+    }
+    
+    @Test
+    public void testKeywordParameter(){
+        compareWithJavaSource("keyword/Parameter");
+    }
 }

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Attribute.ceylon
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Attribute.ceylon
@@ -1,0 +1,33 @@
+@nomodel
+class Attribute() {
+    shared Boolean abstract = false;
+    shared Boolean assert = false;
+    shared Boolean boolean = false;
+    shared Boolean byte = false;
+    shared Boolean char = false;
+    shared Boolean const = false;
+    shared Boolean default = false;
+    shared Boolean do = false;
+    shared Boolean double = false;
+    shared Boolean enum = false;
+    shared Boolean final = false;
+    shared Boolean float = false;
+    shared Boolean goto = false;
+    shared Boolean implements = false;
+    shared Boolean instanceof = false;
+    shared Boolean int = false;
+    shared Boolean long = false;
+    shared Boolean native = false;
+    shared Boolean new = false;
+    shared Boolean package = false;
+    shared Boolean private = false;
+    shared Boolean protected = false;
+    shared Boolean public = false;
+    shared Boolean short = false;
+    shared Boolean static = false;
+    shared Boolean strictfp = false;
+    shared Boolean synchronized = false;
+    shared Boolean throws = false;
+    shared Boolean transient = false;
+    shared Boolean volatile = false;
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Attribute.src
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Attribute.src
@@ -1,0 +1,187 @@
+package com.redhat.ceylon.compiler.test.misc.keyword;
+
+class Attribute {
+    private final boolean abstract;
+    
+    public final boolean getAbstract() {
+        return this.abstract;
+    }
+    private final boolean assert;
+    
+    public final boolean getAssert() {
+        return this.assert;
+    }
+    private final boolean boolean;
+    
+    public final boolean getBoolean() {
+        return this.boolean;
+    }
+    private final boolean byte;
+    
+    public final boolean getByte() {
+        return this.byte;
+    }
+    private final boolean char;
+    
+    public final boolean getChar() {
+        return this.char;
+    }
+    private final boolean const;
+    
+    public final boolean getConst() {
+        return this.const;
+    }
+    private final boolean default;
+    
+    public final boolean getDefault() {
+        return this.default;
+    }
+    private final boolean do;
+    
+    public final boolean getDo() {
+        return this.do;
+    }
+    private final boolean double;
+    
+    public final boolean getDouble() {
+        return this.double;
+    }
+    private final boolean enum;
+    
+    public final boolean getEnum() {
+        return this.enum;
+    }
+    private final boolean final;
+    
+    public final boolean getFinal() {
+        return this.final;
+    }
+    private final boolean float;
+    
+    public final boolean getFloat() {
+        return this.float;
+    }
+    private final boolean goto;
+    
+    public final boolean getGoto() {
+        return this.goto;
+    }
+    private final boolean implements;
+    
+    public final boolean getImplements() {
+        return this.implements;
+    }
+    private final boolean instanceof;
+    
+    public final boolean getInstanceof() {
+        return this.instanceof;
+    }
+    private final boolean int;
+    
+    public final boolean getInt() {
+        return this.int;
+    }
+    private final boolean long;
+    
+    public final boolean getLong() {
+        return this.long;
+    }
+    private final boolean native;
+    
+    public final boolean getNative() {
+        return this.native;
+    }
+    private final boolean new;
+    
+    public final boolean getNew() {
+        return this.new;
+    }
+    private final boolean package;
+    
+    public final boolean getPackage() {
+        return this.package;
+    }
+    private final boolean private;
+    
+    public final boolean getPrivate() {
+        return this.private;
+    }
+    private final boolean protected;
+    
+    public final boolean getProtected() {
+        return this.protected;
+    }
+    private final boolean public;
+    
+    public final boolean getPublic() {
+        return this.public;
+    }
+    private final boolean short;
+    
+    public final boolean getShort() {
+        return this.short;
+    }
+    private final boolean static;
+    
+    public final boolean getStatic() {
+        return this.static;
+    }
+    private final boolean strictfp;
+    
+    public final boolean getStrictfp() {
+        return this.strictfp;
+    }
+    private final boolean synchronized;
+    
+    public final boolean getSynchronized() {
+        return this.synchronized;
+    }
+    private final boolean throws;
+    
+    public final boolean getThrows() {
+        return this.throws;
+    }
+    private final boolean transient;
+    
+    public final boolean getTransient() {
+        return this.transient;
+    }
+    private final boolean volatile;
+    
+    public final boolean getVolatile() {
+        return this.volatile;
+    }
+    
+    Attribute() {
+        this.abstract = false;
+        this.assert = false;
+        this.boolean = false;
+        this.byte = false;
+        this.char = false;
+        this.const = false;
+        this.default = false;
+        this.do = false;
+        this.double = false;
+        this.enum = false;
+        this.final = false;
+        this.float = false;
+        this.goto = false;
+        this.implements = false;
+        this.instanceof = false;
+        this.int = false;
+        this.long = false;
+        this.native = false;
+        this.new = false;
+        this.package = false;
+        this.private = false;
+        this.protected = false;
+        this.public = false;
+        this.short = false;
+        this.static = false;
+        this.strictfp = false;
+        this.synchronized = false;
+        this.throws = false;
+        this.transient = false;
+        this.volatile = false;
+    }
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Method.ceylon
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Method.ceylon
@@ -1,0 +1,33 @@
+@nomodel
+class Method() {
+    void abstract() {}
+    void assert() {}
+    void boolean() {}
+    void byte() {}
+    void char() {}
+    void const() {}
+    void default() {}
+    void do() {}
+    void double() {}
+    void enum() {}
+    void final() {}
+    void float() {}
+    void goto() {}
+    void implements() {}
+    void instanceof() {}
+    void int() {}
+    void long() {}
+    void native() {}
+    void new() {}
+    void package() {}
+    void private() {}
+    void protected() {}
+    void public() {}
+    void short() {}
+    void static() {}
+    void strictfp() {}
+    void synchronized() {}
+    void throws() {}
+    void transient() {}
+    void volatile() {}
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Method.src
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Method.src
@@ -1,0 +1,97 @@
+package com.redhat.ceylon.compiler.test.misc.keyword;
+
+class Method {
+    
+    private final void $abstract() {
+    }
+    
+    private final void $assert() {
+    }
+    
+    private final void $boolean() {
+    }
+    
+    private final void $byte() {
+    }
+    
+    private final void $char() {
+    }
+    
+    private final void $const() {
+    }
+    
+    private final void $default() {
+    }
+    
+    private final void $do() {
+    }
+    
+    private final void $double() {
+    }
+    
+    private final void $enum() {
+    }
+    
+    private final void $final() {
+    }
+    
+    private final void $float() {
+    }
+    
+    private final void $goto() {
+    }
+    
+    private final void $implements() {
+    }
+    
+    private final void $instanceof() {
+    }
+    
+    private final void $int() {
+    }
+    
+    private final void $long() {
+    }
+    
+    private final void $native() {
+    }
+    
+    private final void $new() {
+    }
+    
+    private final void $package() {
+    }
+    
+    private final void $private() {
+    }
+    
+    private final void $protected() {
+    }
+    
+    private final void $public() {
+    }
+    
+    private final void $short() {
+    }
+    
+    private final void $static() {
+    }
+    
+    private final void $strictfp() {
+    }
+    
+    private final void $synchronized() {
+    }
+    
+    private final void $throws() {
+    }
+    
+    private final void $transient() {
+    }
+    
+    private final void $volatile() {
+    }
+    
+    Method() {
+    }
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Parameter.ceylon
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Parameter.ceylon
@@ -1,0 +1,33 @@
+@nomodel
+class Parameter() {
+    void m1(Boolean abstract) {}
+    void m2(Boolean assert) { }
+    void m3(Boolean boolean) { }
+    void m4(Boolean byte) { }
+    void m5(Boolean char) { }
+    void m6(Boolean const) { }
+    void m7(Boolean default) { }
+    void m8(Boolean do) { }
+    void m9(Boolean double) { }
+    void m10(Boolean enum) { }
+    void m11(Boolean final) { }
+    void m12(Boolean float) { }
+    void m13(Boolean goto) { }
+    void m14(Boolean implements) { }
+    void m15(Boolean instanceof) { }
+    void m16(Boolean int) { }
+    void m17(Boolean long) { }
+    void m18(Boolean native) { }
+    void m19(Boolean new) { }
+    void m20(Boolean package) { }
+    void m21(Boolean private) { }
+    void m22(Boolean protected) { }
+    void m23(Boolean public) { }
+    void m24(Boolean short) { }
+    void m25(Boolean static) { }
+    void m26(Boolean strictfp) { }
+    void m27(Boolean synchronized) { }
+    void m28(Boolean throws) { }
+    void m29(Boolean transient) { }
+    void m30(Boolean volatile) { }
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Parameter.src
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Parameter.src
@@ -1,0 +1,97 @@
+package com.redhat.ceylon.compiler.test.misc.keyword;
+
+class Parameter {
+    
+    private final void m1(final boolean abstract) {
+    }
+    
+    private final void m2(final boolean assert) {
+    }
+    
+    private final void m3(final boolean boolean) {
+    }
+    
+    private final void m4(final boolean byte) {
+    }
+    
+    private final void m5(final boolean char) {
+    }
+    
+    private final void m6(final boolean const) {
+    }
+    
+    private final void m7(final boolean default) {
+    }
+    
+    private final void m8(final boolean do) {
+    }
+    
+    private final void m9(final boolean double) {
+    }
+    
+    private final void m10(final boolean enum) {
+    }
+    
+    private final void m11(final boolean final) {
+    }
+    
+    private final void m12(final boolean float) {
+    }
+    
+    private final void m13(final boolean goto) {
+    }
+    
+    private final void m14(final boolean implements) {
+    }
+    
+    private final void m15(final boolean instanceof) {
+    }
+    
+    private final void m16(final boolean int) {
+    }
+    
+    private final void m17(final boolean long) {
+    }
+    
+    private final void m18(final boolean native) {
+    }
+    
+    private final void m19(final boolean new) {
+    }
+    
+    private final void m20(final boolean package) {
+    }
+    
+    private final void m21(final boolean private) {
+    }
+    
+    private final void m22(final boolean protected) {
+    }
+    
+    private final void m23(final boolean public) {
+    }
+    
+    private final void m24(final boolean short) {
+    }
+    
+    private final void m25(final boolean static) {
+    }
+    
+    private final void m26(final boolean strictfp) {
+    }
+    
+    private final void m27(final boolean synchronized) {
+    }
+    
+    private final void m28(final boolean throws) {
+    }
+    
+    private final void m29(final boolean transient) {
+    }
+    
+    private final void m30(final boolean volatile) {
+    }
+    
+    Parameter() {
+    }
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Variable.ceylon
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Variable.ceylon
@@ -1,0 +1,35 @@
+@nomodel
+class Variable() {
+    void m() {
+        Boolean abstract = false;
+        Boolean assert = false;
+        Boolean boolean = false;
+        Boolean byte = false;
+        Boolean char = false;
+        Boolean const = false;
+        Boolean default = false;
+        Boolean do = false;
+        Boolean double = false;
+        Boolean enum = false;
+        Boolean final = false;
+        Boolean float = false;
+        Boolean goto = false;
+        Boolean implements = false;
+        Boolean instanceof = false;
+        Boolean int = false;
+        Boolean long = false;
+        Boolean native = false;
+        Boolean new = false;
+        Boolean package = false;
+        Boolean private = false;
+        Boolean protected = false;
+        Boolean public = false;
+        Boolean short = false;
+        Boolean static = false;
+        Boolean strictfp = false;
+        Boolean synchronized = false;
+        Boolean throws = false;
+        Boolean transient = false;
+        Boolean volatile = false;
+    }
+}

--- a/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Variable.src
+++ b/test-src/com/redhat/ceylon/compiler/test/misc/keyword/Variable.src
@@ -1,0 +1,40 @@
+package com.redhat.ceylon.compiler.test.misc.keyword;
+
+class Variable {
+    
+    private final void m() {
+        final boolean abstract = false;
+        final boolean assert = false;
+        final boolean boolean = false;
+        final boolean byte = false;
+        final boolean char = false;
+        final boolean const = false;
+        final boolean default = false;
+        final boolean do = false;
+        final boolean double = false;
+        final boolean enum = false;
+        final boolean final = false;
+        final boolean float = false;
+        final boolean goto = false;
+        final boolean implements = false;
+        final boolean instanceof = false;
+        final boolean int = false;
+        final boolean long = false;
+        final boolean native = false;
+        final boolean new = false;
+        final boolean package = false;
+        final boolean private = false;
+        final boolean protected = false;
+        final boolean public = false;
+        final boolean short = false;
+        final boolean static = false;
+        final boolean strictfp = false;
+        final boolean synchronized = false;
+        final boolean throws = false;
+        final boolean transient = false;
+        final boolean volatile = false;
+    }
+    
+    Variable() {
+    }
+}


### PR DESCRIPTION
Tests for Java keyword avoidance, addressing #26.

Note that javac seems to be happy with identifiers that are keywords (presumably its only in the parser that they have special meaning).

For interop it's necessary to escape method names, but for local variables, attributes, and method params it should be OK not to escape.

Note that class names and generic type params in Ceylon begin with an upper case, meaning no collision with Java keywords is even possible for these.
