### PR TITLE
Adding the module imports in the runtime

### DIFF
--- a/runtime/ceylon/language/descriptor/Import.java
+++ b/runtime/ceylon/language/descriptor/Import.java
@@ -1,0 +1,37 @@
+package ceylon.language.descriptor;
+
+import com.redhat.ceylon.compiler.metadata.java.Name;
+import com.redhat.ceylon.compiler.metadata.java.TypeInfo;
+
+public class Import {
+    private ceylon.language.Quoted name;
+    private ceylon.language.Quoted version;
+    private ceylon.language.Boolean optional;
+    private ceylon.language.Boolean export;
+
+    public Import(@Name("name") ceylon.language.Quoted name, 
+            @Name("version") ceylon.language.Quoted version, 
+            @TypeInfo("ceylon.language.Nothing|ceylon.language.Boolean") @Name("optional") ceylon.language.Boolean optional, 
+            @TypeInfo("ceylon.language.Nothing|ceylon.language.Boolean") @Name("export") ceylon.language.Boolean export) {
+        this.name = name;
+        this.version = version;
+        this.optional = optional;
+        this.export = export;
+    }
+
+    public ceylon.language.Quoted getName() {
+        return name;
+    }
+
+    public ceylon.language.Quoted getVersion() {
+        return version;
+    }
+
+    public ceylon.language.Boolean getOptional() {
+        return optional;
+    }
+
+    public ceylon.language.Boolean getExport() {
+        return export;
+    }
+}

--- a/runtime/ceylon/language/descriptor/Module.java
+++ b/runtime/ceylon/language/descriptor/Module.java
@@ -11,6 +11,7 @@ public class Module {
     private ceylon.language.String doc;
     private Iterable<? extends ceylon.language.String> authors;
     private ceylon.language.Quoted license;
+    private Iterable<? extends ceylon.language.descriptor.Import> dependencies;
 
     public Module(@Name("name") ceylon.language.Quoted name, 
             @Name("version") ceylon.language.Quoted version, 
@@ -19,12 +20,15 @@ public class Module {
             @TypeInfo("ceylon.language.Empty|ceylon.language.Sequence<ceylon.language.String>") @Name("authors") 
               ceylon.language.Iterable<? extends ceylon.language.String> authors, 
             @TypeInfo("ceylon.language.Nothing|ceylon.language.Quoted") @Name("license") 
-    ceylon.language.Quoted license){
+              ceylon.language.Quoted license,
+            @TypeInfo("ceylon.language.Empty|ceylon.language.Sequence<ceylon.language.descriptor.Import>") @Name("dependencies") 
+              ceylon.language.Iterable<? extends ceylon.language.descriptor.Import> dependencies){
         this.name = name;
         this.version = version;
         this.doc = doc;
         this.authors = authors;
         this.license = license;
+        this.dependencies = dependencies;
     }
 
     public ceylon.language.Quoted getName() {
@@ -45,5 +49,9 @@ public class Module {
 
     public ceylon.language.Quoted getLicense() {
         return license;
+    }
+
+    public Iterable<? extends ceylon.language.descriptor.Import> getDependencies() {
+        return dependencies;
     }
 }


### PR DESCRIPTION
Be careful : only named parameters are supported so dependencies should always be there now.

So some tests (test.ceylon and test.structure) should have their _module.ceylon_ file changed to avoid failing after this modification.
