### PR TITLE
Fixing broken build on Mac OS X

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -156,6 +156,7 @@
        srcdir="${javac.src}:${ceylonc.src}"
        destdir="${build.classes}"
        debug="true"
+       encoding="UTF-8"
        classpathref="compiler.classpath"
        includeantruntime="true">
       <include name="com/redhat/**"/>
@@ -176,6 +177,7 @@
        srcdir="${test.src}"
        destdir="${build.classes}"
        debug="true"
+       encoding="UTF-8"
        classpathref="test.compile.classpath"
        includeantruntime="false">
       <include name="com/redhat/ceylon/compiler/java/test/**"/>


### PR DESCRIPTION
Hi guys,

The default encoding on javac on Mac is not UTF-8, and thus,
com.redhat.ceylon.compiler.java.test.interop.JavaBean.getÉpardaud
won't compile on Mac OS without explicitly enforcing encoding for javac.

This commit has the patch for Mac OS X, and I verified it on Mac OS X Leopard.

Cheers,
Soheil
