### PR TITLE
fix. ceylondoc parameter documentation

### DIFF
--- a/src/com/redhat/ceylon/ceylondoc/Util.java
+++ b/src/com/redhat/ceylon/ceylondoc/Util.java
@@ -91,7 +91,11 @@ public class Util {
     }
 
     public static String wikiToHTML(String text) {
-        return new MarkdownProcessor().markdown(text);
+        if( text == null || text.isEmpty() ) {
+            return text;
+        } else {
+            return new MarkdownProcessor().markdown(text);
+        }
     }
 
     private static String getFirstLine(String text) {


### PR DESCRIPTION
In `ClassOrPackageDoc.writeParameters`, I call

```
String doc = getDoc(parameter);
if( !doc.isEmpty() )
```

but current implementation `Util.wikiToHTML` return `"/n"` for null or empty string, so parameters section is rendered always.
