### PR TITLE
README: update test directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Directory structure
 * `lib`       - compile/runtime dependencies
 * `src`       - the Ceylon compiler backend sources
 * `langtools` - the OpenJDK Javac compiler sources
-* `test-src`  - the Ceylon compiler backend unit tests
+* `test`      - the Ceylon compiler backend unit tests
 
 Build the compiler and tools
 ----------------------------


### PR DESCRIPTION
`test-src` was moved to `test` in dc407b5 – over a year ago :)

Should there be explanations for the individual subdirectories of `test`?
