### PR TITLE
Fix tests for Correspondence.keys change

### DIFF
--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug04xx/Bug446.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug04xx/Bug446.src
@@ -341,7 +341,7 @@ abstract class Bug446<T> implements .com.redhat.ceylon.compiler.java.runtime.mod
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug04xx/Bug476.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug04xx/Bug476.src
@@ -439,7 +439,7 @@ public abstract class Bug476<T> implements .com.redhat.ceylon.compiler.java.runt
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug04xx/Bug477.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug04xx/Bug477.src
@@ -341,7 +341,7 @@ abstract class Bug477_1<T> implements .com.redhat.ceylon.compiler.java.runtime.m
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     
@@ -740,7 +740,7 @@ abstract class Bug477_2<T> implements .com.redhat.ceylon.compiler.java.runtime.m
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug08xx/Bug837.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug08xx/Bug837.src
@@ -347,7 +347,7 @@ class Bug837<Element extends .ceylon.language.Ordinal<? extends Element>> extend
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug08xx/Bug844.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug08xx/Bug844.src
@@ -409,7 +409,7 @@ public abstract class Bug844_Tuple<Element, First extends Element, Rest> extends
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug09xx/Bug966.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug09xx/Bug966.src
@@ -356,7 +356,7 @@ public abstract class Bug966<Element extends .ceylon.language.Ordinal<? extends 
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/issues/bug14xx/Bug1430.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/issues/bug14xx/Bug1430.src
@@ -331,7 +331,7 @@ class Bug1430 implements .com.redhat.ceylon.compiler.java.runtime.model.ReifiedT
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     

--- a/test/src/com/redhat/ceylon/compiler/java/test/structure/concrete/ListImplementor.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/structure/concrete/ListImplementor.src
@@ -339,7 +339,7 @@ class ListImplementor<X> implements .com.redhat.ceylon.compiler.java.runtime.mod
     }
     
     @.java.lang.Override
-    public .ceylon.language.Category<? super .java.lang.Object> getKeys() {
+    public .ceylon.language.Category<? super .ceylon.language.Integer> getKeys() {
         return $ceylon$language$Correspondence$this$.getKeys();
     }
     


### PR DESCRIPTION
Correspondence.keys was changed from `Category` to `Category<Key>`, therefore the Java return type of `List.keys` changed from `Category<? super .java.lang.Object>` to `Category<? super .ceylon.language.Integer>`.

Requires ceylon/ceylon.language#464.
