### PR TITLE
Add attributes to ceylon-test, ceylon-test-js tasks

### DIFF
--- a/src/com/redhat/ceylon/ant/CeylonTestAntTask.java
+++ b/src/com/redhat/ceylon/ant/CeylonTestAntTask.java
@@ -36,6 +36,7 @@ public class CeylonTestAntTask extends RepoUsingCeylonAntTask {
     
     private final ModuleSet moduleSet = new ModuleSet();
     private String compileFlags;
+    private String version;
     private Boolean tap = false;
     private Boolean report = false;
     
@@ -74,6 +75,13 @@ public class CeylonTestAntTask extends RepoUsingCeylonAntTask {
     }
     
     /**
+     * Sets the ceylon.test module version.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    
+    /**
      * Enables the Test Anything Protocol v13.
      * @param tap
      */
@@ -109,6 +117,9 @@ public class CeylonTestAntTask extends RepoUsingCeylonAntTask {
         
         if(compileFlags != null){
             appendOptionArgument(cmd, "--compile", compileFlags);
+        }
+        if(version != null) {
+            appendOptionArgument(cmd, "--version", version);
         }
         if(tap) {
             appendOption(cmd, "--tap");

--- a/src/com/redhat/ceylon/ant/CeylonTestJsAntTask.java
+++ b/src/com/redhat/ceylon/ant/CeylonTestJsAntTask.java
@@ -26,17 +26,22 @@
 package com.redhat.ceylon.ant;
 
 import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.DynamicAttribute;
 import org.apache.tools.ant.Project;
+import org.apache.tools.ant.UnsupportedAttributeException;
 import org.apache.tools.ant.types.Commandline;
 
 
-public class CeylonTestJsAntTask extends RepoUsingCeylonAntTask {
+public class CeylonTestJsAntTask extends RepoUsingCeylonAntTask implements DynamicAttribute {
 
     static final String FAIL_MSG = "Test failed; see the error output for details.";
     
     private final ModuleSet moduleSet = new ModuleSet();
     private String compileFlags;
+    private String version;
+    private String nodeExe;
     private Boolean tap = false;
+    private Boolean debug = true;
     private Boolean report = false;
     
     public CeylonTestJsAntTask() {
@@ -64,6 +69,33 @@ public class CeylonTestJsAntTask extends RepoUsingCeylonAntTask {
      */
     public void setCompile(String compileFlags) {
         this.compileFlags = compileFlags;
+    }
+    
+    /**
+     * Sets the version of the ceylon.test module to use.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    
+    /**
+     * For the attribute name 'node-exe', sets the path to the node.js executable.
+     * <p>
+     * (This is a bit convoluted because 'setNode-exe' is not a legal Java method name.)
+     */
+    public void setDynamicAttribute(String name, String value) {
+        if (name.equals("node-exe")) {
+            this.nodeExe = value;
+        } else {
+            throw new UnsupportedAttributeException("ceylon-test-js does not support the \"" + name + "\" attribute.", name);
+        }
+    }
+    
+    /**
+     * Enables more detailed output on errors.
+     */
+    public void setDebug(Boolean debug) {
+        this.debug = debug;
     }
     
     /**
@@ -102,6 +134,15 @@ public class CeylonTestJsAntTask extends RepoUsingCeylonAntTask {
         
         if(compileFlags != null){
             appendOptionArgument(cmd, "--compile", compileFlags);
+        }
+        if(version != null){
+            appendOptionArgument(cmd, "--version", version);
+        }
+        if(nodeExe != null){
+            appendOptionArgument(cmd, "--node-exe", nodeExe);
+        }
+        if(debug != null) { // defaults to true, so set it like an option argument, not like a flag option
+            appendOptionArgument(cmd, "--debug", debug.toString());
         }
         if(tap) {
             appendOption(cmd, "--tap");


### PR DESCRIPTION
`ceylon-test` learned the `version` attribute, and `ceylon-test-js` learned the `version`, `node-exe` and `debug` attributes.

CC @quintesse.
