### PR TITLE
Improve handling of non-BMP attribute names

### DIFF
--- a/src/com/redhat/ceylon/compiler/java/codegen/Naming.java
+++ b/src/com/redhat/ceylon/compiler/java/codegen/Naming.java
@@ -358,7 +358,7 @@ public class Naming implements LocalId {
     }
 
     public static String capitalize(String str){
-        return str.substring(0, 1).toUpperCase() + str.substring(1);
+        return new StringBuilder().appendCodePoint(Character.toUpperCase(str.codePointAt(0))).append(str.substring(Character.isSurrogate(str.charAt(0)) ? 2 : 1)).toString();
     }
     
     /** 

--- a/src/com/redhat/ceylon/compiler/loader/AbstractModelLoader.java
+++ b/src/com/redhat/ceylon/compiler/loader/AbstractModelLoader.java
@@ -2540,8 +2540,8 @@ public abstract class AbstractModelLoader implements ModelCompleter, ModelLoader
         return result;
     }
     
-    private boolean isStartOfJavaBeanPropertyName(char c){
-        return Character.isUpperCase(c) || c == '_'; 
+    private boolean isStartOfJavaBeanPropertyName(int c){
+        return (c == Character.toUpperCase(c)) || c == '_'; 
     }
 
     private boolean isNonGenericMethod(MethodMirror methodMirror){
@@ -2554,10 +2554,10 @@ public abstract class AbstractModelLoader implements ModelCompleter, ModelLoader
             return false;
         String name = methodMirror.getName();
         boolean matchesGet = name.length() > 3 && name.startsWith("get") 
-                && isStartOfJavaBeanPropertyName(name.charAt(3)) 
+                && isStartOfJavaBeanPropertyName(name.codePointAt(3)) 
                 && !"getString".equals(name) && !"getHash".equals(name) && !"getEquals".equals(name);
         boolean matchesIs = name.length() > 2 && name.startsWith("is") 
-                && isStartOfJavaBeanPropertyName(name.charAt(2)) 
+                && isStartOfJavaBeanPropertyName(name.codePointAt(2)) 
                 && !"isString".equals(name) && !"isHash".equals(name) && !"isEquals".equals(name);
         boolean hasNoParams = methodMirror.getParameters().size() == 0;
         boolean hasNonVoidReturn = (methodMirror.getReturnType().getKind() != TypeKind.VOID);
@@ -2570,7 +2570,7 @@ public abstract class AbstractModelLoader implements ModelCompleter, ModelLoader
             return false;
         String name = methodMirror.getName();
         boolean matchesSet = name.length() > 3 && name.startsWith("set") 
-                && isStartOfJavaBeanPropertyName(name.charAt(3))
+                && isStartOfJavaBeanPropertyName(name.codePointAt(3))
                 && !"setString".equals(name) && !"setHash".equals(name) && !"setEquals".equals(name);
         boolean hasOneParam = methodMirror.getParameters().size() == 1;
         boolean hasVoidReturn = (methodMirror.getReturnType().getKind() == TypeKind.VOID);

--- a/test/src/com/redhat/ceylon/compiler/java/test/metamodel/MetamodelTests.java
+++ b/test/src/com/redhat/ceylon/compiler/java/test/metamodel/MetamodelTests.java
@@ -83,5 +83,11 @@ public class MetamodelTests extends CompilerTests {
     public void testBug1926() {
         compareWithJavaSource("bug1926");
     }
+    
+    @Test
+    public void testBugCL634() {
+        compareWithJavaSource("bugCL634");
+        run("com.redhat.ceylon.compiler.java.test.metamodel.bugCL634");
+    }
 }
 

--- a/test/src/com/redhat/ceylon/compiler/java/test/metamodel/bugCL634.ceylon
+++ b/test/src/com/redhat/ceylon/compiler/java/test/metamodel/bugCL634.ceylon
@@ -1,0 +1,28 @@
+import ceylon.language.meta.declaration {
+    NestableDeclaration
+}
+@noanno
+class BugCL634() {
+    @noanno
+    shared Null good = null; // regular ASCII
+    @noanno
+    shared Null 𝒷𝒶𝒹 = null; // Mathematical Alphanumerical Symbols – non-BMP, but no uppercase mapping
+    @noanno
+    shared Null 𐐨 = null; // Deseret – non-BMP and has uppercase variant
+}
+@noanno
+shared void bugCL634() {
+    assert (`class BugCL634`.declaredMemberDeclarations<NestableDeclaration>().size == 2);
+    assert (`BugCL634`.getDeclaredAttributes<BugCL634>().size == 2);
+    assert (`BugCL634`.getDeclaredMethods<BugCL634>() == []);
+    assert ((`BugCL634.good` of Anything) exists);
+    assert ((`BugCL634.𝒷𝒶𝒹` of Anything) exists);
+    assert ((`BugCL634.𐐨` of Anything) exists);
+    assert (!`BugCL634`.getMethod<BugCL634>("getGood") exists);
+    assert (!`BugCL634`.getMethod<BugCL634>("get𝒷𝒶𝒹") exists);
+    assert (!`BugCL634`.getMethod<BugCL634>("get𐐨") exists);
+    assert (!`BugCL634`.getMethod<BugCL634>("get𐐀") exists);
+    assert (`BugCL634`.getAttribute<BugCL634>("good") exists);
+    assert (`BugCL634`.getAttribute<BugCL634>("𝒷𝒶𝒹") exists);
+    assert (`BugCL634`.getAttribute<BugCL634>("𐐨") exists);
+}

--- a/test/src/com/redhat/ceylon/compiler/java/test/metamodel/bugCL634.src
+++ b/test/src/com/redhat/ceylon/compiler/java/test/metamodel/bugCL634.src
@@ -1,0 +1,96 @@
+package com.redhat.ceylon.compiler.java.test.metamodel;
+
+class BugCL634 implements .com.redhat.ceylon.compiler.java.runtime.model.ReifiedType {
+    
+    BugCL634() {
+        this.good = null;
+        this.\ud835\udcb7\ud835\udcb6\ud835\udcb9 = null;
+        this.\ud801\udc28 = null;
+    }
+    private final .java.lang.Object good;
+    
+    public final .java.lang.Object getGood() {
+        return good;
+    }
+    private final .java.lang.Object \ud835\udcb7\ud835\udcb6\ud835\udcb9;
+    
+    public final .java.lang.Object get\ud835\udcb7\ud835\udcb6\ud835\udcb9() {
+        return \ud835\udcb7\ud835\udcb6\ud835\udcb9;
+    }
+    private final .java.lang.Object \ud801\udc28;
+    
+    public final .java.lang.Object get\ud801\udc00() {
+        return \ud801\udc28;
+    }
+    
+    @.java.lang.Override
+    public .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor $getType$() {
+        return .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$;
+    }
+    public static final .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor $TypeDescriptor$ = .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.klass(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.class);
+}
+public final class bugCL634_ {
+    
+    private bugCL634_() {
+    }
+    
+    public static void bugCL634() {
+        if (((.ceylon.language.Sequential<? extends .ceylon.language.meta.declaration.NestableDeclaration>)(.ceylon.language.Sequential)((.ceylon.language.meta.declaration.ClassDeclaration).com.redhat.ceylon.compiler.java.runtime.metamodel.Metamodel.getOrCreateMetamodel(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.class)).<.ceylon.language.meta.declaration.NestableDeclaration>declaredMemberDeclarations(.ceylon.language.meta.declaration.NestableDeclaration.$TypeDescriptor$)).getSize() == 2L) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "`class BugCL634`.declaredMemberDeclarations<NestableDeclaration>().size == 2"));
+        }
+        if (((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .java.lang.Object>getDeclaredAttributes(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType).getSize() == 2L) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "`BugCL634`.getDeclaredAttributes<BugCL634>().size == 2"));
+        }
+        if (((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .ceylon.language.Sequential<? extends .java.lang.Object>>getDeclaredMethods(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType).equals(.ceylon.language.empty_.get_())) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "`BugCL634`.getDeclaredMethods<BugCL634>() == []"));
+        }
+        if ((.ceylon.language.meta.model.Attribute)(.ceylon.language.meta.model.Attribute)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).getAttribute(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Null.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "good") != null) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "(`BugCL634.good` of Anything) exists"));
+        }
+        if ((.ceylon.language.meta.model.Attribute)(.ceylon.language.meta.model.Attribute)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).getAttribute(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Null.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "\ud835\udcb7\ud835\udcb6\ud835\udcb9") != null) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "(`BugCL634.\ud835\udcb7\ud835\udcb6\ud835\udcb9` of Anything) exists"));
+        }
+        if ((.ceylon.language.meta.model.Attribute)(.ceylon.language.meta.model.Attribute)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).getAttribute(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Null.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "\ud801\udc28") != null) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "(`BugCL634.\ud801\udc28` of Anything) exists"));
+        }
+        if (!((.ceylon.language.meta.model.Method)(.ceylon.language.meta.model.Method)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .ceylon.language.Sequential<? extends .java.lang.Object>>getMethod(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "getGood") != null)) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "!`BugCL634`.getMethod<BugCL634>(\"getGood\") exists"));
+        }
+        if (!((.ceylon.language.meta.model.Method)(.ceylon.language.meta.model.Method)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .ceylon.language.Sequential<? extends .java.lang.Object>>getMethod(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "get\ud835\udcb7\ud835\udcb6\ud835\udcb9") != null)) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "!`BugCL634`.getMethod<BugCL634>(\"get\ud835\udcb7\ud835\udcb6\ud835\udcb9\") exists"));
+        }
+        if (!((.ceylon.language.meta.model.Method)(.ceylon.language.meta.model.Method)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .ceylon.language.Sequential<? extends .java.lang.Object>>getMethod(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "get\ud801\udc28") != null)) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "!`BugCL634`.getMethod<BugCL634>(\"get\ud801\udc28\") exists"));
+        }
+        if (!((.ceylon.language.meta.model.Method)(.ceylon.language.meta.model.Method)((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .ceylon.language.Sequential<? extends .java.lang.Object>>getMethod(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "get\ud801\udc00") != null)) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "!`BugCL634`.getMethod<BugCL634>(\"get\ud801\udc00\") exists"));
+        }
+        if (((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .java.lang.Object>getAttribute(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "good") != null) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "`BugCL634`.getAttribute<BugCL634>(\"good\") exists"));
+        }
+        if (((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .java.lang.Object>getAttribute(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "\ud835\udcb7\ud835\udcb6\ud835\udcb9") != null) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "`BugCL634`.getAttribute<BugCL634>(\"\ud835\udcb7\ud835\udcb6\ud835\udcb9\") exists"));
+        }
+        if (((.ceylon.language.meta.model.ClassOrInterface<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634>)(.ceylon.language.meta.model.Class<? extends .com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, ? super .ceylon.language.Empty>).ceylon.language.meta.typeLiteral_.typeLiteral(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$)).<.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634, .java.lang.Object, .java.lang.Object>getAttribute(.com.redhat.ceylon.compiler.java.test.metamodel.BugCL634.$TypeDescriptor$, .ceylon.language.Anything.$TypeDescriptor$, .com.redhat.ceylon.compiler.java.runtime.model.TypeDescriptor.NothingType, "\ud801\udc28") != null) {
+        } else {
+            throw new .ceylon.language.AssertionError("Assertion failed" + (.java.lang.System.lineSeparator() + "\tviolated " + "`BugCL634`.getAttribute<BugCL634>(\"\ud801\udc28\") exists"));
+        }
+    }
+    
+    public static void main(.java.lang.String[] args) {
+        .ceylon.language.process_.get_().setupArguments(args);
+        .com.redhat.ceylon.compiler.java.test.metamodel.bugCL634_.bugCL634();
+    }
+}


### PR DESCRIPTION
This incorporates two changes:

1. `Naming.capitalize` now correctly handles characters outside the Basic Multilingual Plane, that is, characters that don't fit within a single Java `char`. Theoretically, this breaks binary compatibility: if the name of an attribute begins with a character outside the BMP that has an uppercase variant (for example, a lowercase Deseret character), then the getter is now called `getX` (where `X` is the uppercase variant), whereas previously it was called `getx` (`x` being the lowercase variant). However, I find it very unlikely that anyone would actually have done that.
2. `AbstractModelLoader.isStartOfJavaBeanPropertyName` now uses codepoints instead of characters as well; in addition, its logic has been slightly changed: instead of checking whether the character after the "get" is uppercased, it now checks whether that character is equal to its uppercase variant. This makes a difference if the character does not have an uppercase variant, i. e., it is its own uppercase version. This part fixes ceylon/ceylon.language#634.

I’m getting some test failures here; I’m mostly confident that they’re unrelated to this change, but someone else should definitely still check that.