### PR TITLE
Ceylon compiler issue #2117

### DIFF
--- a/test/src/com/redhat/ceylon/tools/test/CompilerToolTests.java
+++ b/test/src/com/redhat/ceylon/tools/test/CompilerToolTests.java
@@ -438,9 +438,10 @@ public class CompilerToolTests extends AbstractToolTests {
         
         try {
             CeylonCompileTool tool = pluginFactory.bindArguments(model, getMainTool(),
-                    options("--suppress-warnings=blah"));
+                    options("--suppress-warning=blah"));
             Assert.fail("Tool should have thrown an exception");
         } catch (OptionArgumentException e) {
+        	Assert.assertEquals("Invalid value 'blah' given for option 'suppress-warning' to command 'compile'", e.getMessage());
             // We expect this, not a FatalToolError
         }
         

--- a/test/src/com/redhat/ceylon/tools/test/CompilerToolTests.java
+++ b/test/src/com/redhat/ceylon/tools/test/CompilerToolTests.java
@@ -75,6 +75,15 @@ public class CompilerToolTests extends AbstractToolTests {
     }
 
     @Test
+    public void testIssueGH2117_suppress_warning_BindingRaisingIllegalArgumentEx()  throws Exception {
+        ToolModel<CeylonCompileTool> model = pluginLoader.loadToolModel("compile");
+        Assert.assertNotNull(model);
+		pluginFactory.bindArguments(model, getMainTool(), options(
+				"--src=test/src", "com.redhat.ceylon.tools.test.ceylon",
+				"--suppress-warning"));
+    }
+
+    @Test
     public void testCompileKeywordsInModuleName()  throws Exception {
         ToolModel<CeylonCompileTool> model = pluginLoader.loadToolModel("compile");
         Assert.assertNotNull(model);


### PR DESCRIPTION
Just add test for #2117, actual fix is committed in ceylon/ceylon-common#54

When no waring are defined on the command line, all warnings will be used (actually suppressed)

This fix was mentored by @FroMage during the hackergarten at Devoxx France 2015