### PR TITLE
Update tests for type parser defaulted types

### DIFF
--- a/test/src/com/redhat/ceylon/compiler/java/test/model/TypeParserTests.java
+++ b/test/src/com/redhat/ceylon/compiler/java/test/model/TypeParserTests.java
@@ -717,6 +717,19 @@ public class TypeParserTests {
     }
     
     @Test
+    public void testTuple1To3Abbrev(){
+        Type type = new TypeParser(MockLoader.instance).decodeType("[a,b=,c=]", null, mockDefaultModule, mockPkgUnit);
+        Assert.assertNotNull(type);
+        TypeDeclaration declaration = type.getDeclaration();
+        Assert.assertNotNull(declaration);
+        Assert.assertTrue(declaration instanceof Class);
+        Assert.assertEquals("ceylon.language::Tuple", declaration.getQualifiedNameString());
+        Assert.assertEquals("[a, b=, c=]", type.asString());
+        Assert.assertEquals("ceylon.language::Tuple<a|b|c,a,ceylon.language::Empty|ceylon.language::Tuple<b|c,b,ceylon.language::Empty|ceylon.language::Tuple<c,c,ceylon.language::Empty>>>", printType(type));
+        Assert.assertNull(type.getQualifyingType());
+    }
+    
+    @Test
     public void testHomoTuple1(){
         Type type = new TypeParser(MockLoader.instance).decodeType("a[1]", null, mockDefaultModule, mockPkgUnit);
         Assert.assertNotNull(type);
@@ -792,6 +805,15 @@ public class TypeParserTests {
         Assert.assertTrue(declaration instanceof Interface);
         Assert.assertEquals("ceylon.language::Callable", declaration.getQualifiedNameString());
         Assert.assertEquals("ceylon.language::Callable<a,ceylon.language::Tuple<b|pkg::u,b,ceylon.language::Sequential<pkg::u>>>", printType(type));
+        Assert.assertNull(type.getQualifyingType());
+        
+        type = new TypeParser(MockLoader.instance).decodeType("a(b=,pkg::u*)", null, mockPkgModule, mockPkgUnit);
+        Assert.assertNotNull(type);
+        declaration = type.getDeclaration();
+        Assert.assertNotNull(declaration);
+        Assert.assertTrue(declaration instanceof Interface);
+        Assert.assertEquals("ceylon.language::Callable", declaration.getQualifiedNameString());
+        Assert.assertEquals("ceylon.language::Callable<a,ceylon.language::Empty|ceylon.language::Tuple<b|pkg::u,b,ceylon.language::Sequential<pkg::u>>>", printType(type));
         Assert.assertNull(type.getQualifyingType());
     }
     


### PR DESCRIPTION
See ceylon/ceylon-model#3 and ceylon/ceylon-model#4.

Without these changes, on master, in the CLI, I get 44 failures. With these changes, I get 56. (The number of errors doesn’t change.)

These fall into two categories:

1. `[]` not being assignable to
   
   - intersections of `[]` with something else (e. g. `[]&[][]`, `[]&String[]`)
   - `Object[]`
   
   “Callable's second argument should be sequential `[]` (type)” seems to be the same kind of error.

2. Source code differences:
   
   - some casts are removed (those removals seem reasonable to me)
   - other casts are added or changed, which I don’t understand
   
   In general, I don’t understand how this change could result in different code being generated altogether.

I have to give up at this point, sorry. Perhaps someone else can come to a better solution, hopefully using this.