### PR TITLE
CeylonClassLoader causing NoClassDefFoundError

### DIFF
--- a/src/com/redhat/ceylon/launcher/CeylonClassLoader.java
+++ b/src/com/redhat/ceylon/launcher/CeylonClassLoader.java
@@ -222,16 +222,7 @@ public class CeylonClassLoader extends URLClassLoader {
                 urls.add(parentUrls.nextElement());
             }
         }
-        return new Enumeration<URL>() {
-            Iterator<URL> iter = urls.iterator();
-
-            public boolean hasMoreElements() {
-                return iter.hasNext();
-            }
-            public URL nextElement() {
-                return iter.next();
-            }
-        };
+        return Collections.enumeration(urls);
     }
 
     @Override


### PR DESCRIPTION
When doing ClassLoader magic like I do in `ceylon.build` (file `ceylon/build/tasks/GatewayClassLoader.java`) the anonymous `Enumeration` class distorts the classloader for the Ant wrapper in ceylon.build causing a NoClassDefFoundError.